### PR TITLE
Add RSS feed for FLoC podcast

### DIFF
--- a/my-floc-podcast/feed.rss
+++ b/my-floc-podcast/feed.rss
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>My FLoC Experience</title>
+    <link>https://makercasts.org/</link>
+    <description>My name is Chris, and this year I’m attending the Federated Logic Conference, located in Oxford. This is a mini podcast series about my experiences while I’m here.</description>
+    <language>en</language>
+    <itunes:author>Chris Patuzzo</itunes:author>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:owner>
+      <itunes:name>Chris Patuzzo</itunes:name>
+      <itunes:email>chris@patuzzo.co.uk</itunes:email>
+    </itunes:owner>
+    <itunes:type>serial</itunes:type>
+    <itunes:category text="Technology"/>
+
+    <item>
+      <title>Day 1</title>
+      <link>https://makercasts.org/</link>
+      <guid>https://makercasts.org/my-floc-podcast/episode-1.m4a</guid>
+      <pubDate>Sat, 30 Jun 2018 23:25:11 +0100</pubDate>
+      <author>Chris Patuzzo</author>
+      <description>First, let me tell you a bit about who I am and what this conference is.</description>
+      <enclosure url="https://makercasts.org/my-floc-podcast/episode-1.m4a" length="5212453" type="audio/mp4"/>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
This supplies all of the [metadata required by iTunes](https://help.apple.com/itc/podcasts_connect/#/itcb54353390), which should be enough to satisfy any podcast client. Although you could in principle [submit the feed to iTunes](https://help.apple.com/itc/podcasts_connect/#/itc4f0f5ac7d) once it’s published, you don’t have to do that — just having the feed available will allow people to manually subscribe in a podcast client as long as you tell them the URL.

Some arbitrary decisions I had to make in order for the feed to be valid:

* I used “My FLoC Experience” as the title of the podcast, since that’s the album name in the `episode-1.m4a` file.
* I used https://makercasts.org/ as the URL of the podcast, since it doesn’t have a dedicated page (yet).
* I didn’t include cover art, since there isn’t any.
* I used “Technology” as the [iTunes category](https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12), and didn’t use a subcategory.
* Rather than write a new description for the podcast, I used a couple of sentences from the beginning of episode 1.
* I used “Day 1” as the title of episode 1, since that’s the track title in the `episode-1.m4a` file.
* I used https://makercasts.org/ as the link for episode 1, since there isn’t an episode 1 page (yet).
* I used the full URL of the audio file as the GUID for episode 1, which should be fine since it just has to be unique per logical episode, and I don’t think you intend to publish in multiple audio formats.
* Rather than write a new description for episode 1, I used another sentence from the beginning of it.
* I used the timestamp of 4d47e2b2a795ae3fce32d6f1cf5740d3866a4f0f as the publication date of episode 1.

You should of course feel free to change any or all of these before publishing.